### PR TITLE
Bind ServerRequestInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,10 @@ class AppModule extends AbstractModule
 ````php
 class Foo
 {
-    /**
-     * @var \Psr\Http\Message\ServerRequestInterface
-     */
-    private $request;
-
-    public function __construct(RequestProviderInterface $requestProvider)
+    public function __construct(ServerRequestInterface $serverRequest)
     {
-        $this->request = requestProvider->get();
         // retrieve cookies
-        $cookie = $this->request->getCookieParams(); // $_COOKIE
+        $cookie = $serverRequest->getCookieParams(); // $_COOKIE
     }
 }
 ````

--- a/src/HttpRequestRayProvider.php
+++ b/src/HttpRequestRayProvider.php
@@ -1,0 +1,18 @@
+<?php
+namespace Ray\HttpMessage;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ServerRequestInterface;
+use Ray\Di\ProviderInterface;
+
+final class HttpRequestRayProvider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return (new HttpRequestProvider)->get();
+    }
+}

--- a/src/HttpRequestRayProvider.php
+++ b/src/HttpRequestRayProvider.php
@@ -1,9 +1,6 @@
 <?php
 namespace Ray\HttpMessage;
 
-use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7Server\ServerRequestCreator;
-use Psr\Http\Message\ServerRequestInterface;
 use Ray\Di\ProviderInterface;
 
 final class HttpRequestRayProvider implements ProviderInterface

--- a/src/Psr7Module.php
+++ b/src/Psr7Module.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ray\HttpMessage;
 
+use Nyholm\Psr7\ServerRequest;
 use Ray\Di\AbstractModule;
 
 class Psr7Module extends AbstractModule
@@ -8,5 +9,6 @@ class Psr7Module extends AbstractModule
     protected function configure()
     {
         $this->bind(RequestProviderInterface::class)->to(HttpRequestProvider::class);
+        $this->bind(ServerRequest::class)->toProvider(HttpRequestRayProvider::class);
     }
 }

--- a/tests/Psr7HttpModuleTest.php
+++ b/tests/Psr7HttpModuleTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ray\HttpMessage;
 
+use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Ray\Di\Injector;
@@ -15,6 +16,14 @@ class Psr7HttpModuleTest extends TestCase
         $_SERVER = $this->superGlobalsServer();
         $request = $requestProvider->get();
         $this->assertInstanceOf(ServerRequestInterface::class, $request);
+    }
+
+    public function testPsr7ServerRequestTest()
+    {
+        $injector = new Injector(new Psr7Module);
+        /* @var ServerRequest $serverRequest */
+        $serverRequest = $injector->getInstance(ServerRequest::class);
+        $this->assertInstanceOf(ServerRequest::class, $serverRequest);
     }
 
     public function superGlobalsServer()


### PR DESCRIPTION
Users can directly access `ServerRequestInterface`. (instead of Provider)