### PR TITLE
add support psr/http-message:^2.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.3", "7.4", "8.0", "8.1", "8.2"]'
-      current_stable: 8.3
+      old_stable: '["7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      current_stable: 8.4

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,6 @@
         }
     },
     "scripts": {
-        "post-install-cmd": ["@composer bin all install --ansi"],
-        "post-update-cmd": ["@composer bin all update --ansi"],
         "test": ["./vendor/bin/phpunit"],
         "tests": ["@cs", "@test", "@sa"],
         "coverage": ["php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "psr/http-message": "^1.0|^2.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "nyholm/psr7": "^1.0",
         "nyholm/psr7-server": "^1.0",
         "ray/di": "^2.11",
         "ray/aop": "^2.10.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^8.5.41 || ^9.5",
         "bamarni/composer-bin-plugin": "^1.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0|^2.0",
         "nyholm/psr7": "^1.0",
         "nyholm/psr7-server": "^1.0",
         "ray/di": "^2.11",

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,11 @@
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true
         }
+    },
+    "extra": {
+        "bamarni-bin": {
+            "forward-command": true,
+            "bin-links": true
+        }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Update project dependencies and CI configuration to support newer PHP and PSR HTTP Message standards

Enhancements:
- Expand PSR HTTP Message compatibility to support version 2.0
- Update PHP version support matrix in CI workflow

Build:
- Remove post-install and post-update Composer scripts
- Add Bamarni bin plugin configuration

CI:
- Update GitHub workflow to include PHP 8.3 in old stable versions
- Set current stable PHP version to 8.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflow to track newer stable versions.
  - Expanded compatibility for dependencies, allowing support for newer versions of key packages.
  - Adjusted plugin configuration and removed certain post-install and post-update script hooks in the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->